### PR TITLE
fix(stats): guard negative fromIndex when keeping the last 100 activities

### DIFF
--- a/src/main/java/no/cantara/tools/stats/domain/DailyStatus.java
+++ b/src/main/java/no/cantara/tools/stats/domain/DailyStatus.java
@@ -75,7 +75,7 @@ public class DailyStatus implements Serializable {
                 userSessionActivity = new ArrayList<>();
             }
             ActivityCollection activities = this.activityStatistics.getActivities();
-            List<UserSessionActivity> myLastUserSessions = userSessions.subList(userSessions.size() - 100, userSessions.size());
+            List<UserSessionActivity> myLastUserSessions = userSessions.subList(Math.max(0, userSessions.size() - 100), userSessions.size());
             activities.setUserSessions(myLastUserSessions);
         } catch (Exception e) {
             log.error("Exception in trying to populate userSessions", e);


### PR DESCRIPTION
`addActivityStatistics()` always called `subList(size - 100, size)`, so any poll returning fewer than 100 user sessions - which is most of them, the scheduler runs once a minute - threw:

```
java.lang.IndexOutOfBoundsException: fromIndex = -90
  at no.cantara.tools.stats.domain.DailyStatus.addActivityStatistics(DailyStatus.java:78)
  at no.cantara.tools.stats.status.StatusService.getUserSessionStatusForToday(StatusService.java:259)
```

The `catch` swallowed it and logged `Exception in trying to populate userSessions`, so `setUserSessions()` never ran and the day's activity list stayed empty until a batch of 100 or more happened to arrive. Observed on 1881 prod on 2026-08-21.

The sibling call in `getActivityStatistics()` is already safe behind its `size() > 200` check, so only this one needed the clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)