### PR TITLE
fix(build): pass legacy-peer-deps to the oxc binding npm step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,11 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>install @oxc-parser/binding-linux-x64-gnu --save-optional</arguments>
+                            <!-- Needs legacy-peer-deps for the same reason "install dependencies" above
+                                 passes force: the eslint tooling here is not peer clean (@nuxtjs/eslint-config@12
+                                 wants eslint 8, @nuxt/eslint-config@0.7 wants 8 or 9, the project is on 10),
+                                 so a plain install fails with ERESOLVE. -->
+                            <arguments>install @oxc-parser/binding-linux-x64-gnu --save-optional --legacy-peer-deps</arguments>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
Every Jenkins build since #957 (2026-08-09) has failed, release attempts included:

```
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:2.0.1:npm
        (install oxc binding) on project Whydah-StatisticsDashboard:
        'npm install @oxc-parser/binding-linux-x64-gnu --save-optional' failed. Exit value: 1

npm error code ERESOLVE
npm error While resolving: @nuxt/eslint-config@0.7.6
npm error Found: eslint@10.8.1
npm error peer eslint@"^8.57.0 || ^9.0.0" from @nuxt/eslint-config@0.7.6
```

Trigger: `32543a3 chore(deps): update dependency eslint to v10 (#723)`, merged 2026-08-08, the day before the last green build.

The `install oxc binding` execution ran a plain `npm install`, which re-resolves the whole tree. That tree has never been peer clean, which is why the `install dependencies` execution immediately above it already passes `--force`.

Verified against the real command:

```
npm install @oxc-parser/binding-linux-x64-gnu --save-optional                     -> exit 1, ERESOLVE
npm install @oxc-parser/binding-linux-x64-gnu --save-optional --legacy-peer-deps  -> exit 0
```

Downgrading eslint does not fix it, it only moves the conflict:

| eslint | conflicting peer |
|---|---|
| `^10` | `eslint@"^8.57.0 \|\| ^9.0.0"` from `@nuxt/eslint-config@0.7.6` |
| `^9` | `eslint@"^8.23.0"` from `@nuxtjs/eslint-config@12.0.0` |

A real fix means dropping the legacy `@nuxtjs/eslint-config` + `eslint-plugin-nuxt` pair and migrating to flat config. This PR only unblocks releases in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)